### PR TITLE
Add btc tip query

### DIFF
--- a/packages/bindings/src/lib.rs
+++ b/packages/bindings/src/lib.rs
@@ -1,8 +1,11 @@
 mod querier;
 mod query;
+mod types;
 
 pub use querier::BabylonQuerier;
-pub use query::{BabylonQuery, CurrentEpochResponse};
+pub use query::{BabylonQuery, BtcTipResponse, CurrentEpochResponse, LatestFinalizedEpochResponse};
+pub use types::{BtcBlockHeader, BtcBlockHeaderInfo};
+
 // This export is added to all contracts that import this package, signifying that they require
 // "babylon" support on the chain they run on.
 #[no_mangle]

--- a/packages/bindings/src/querier.rs
+++ b/packages/bindings/src/querier.rs
@@ -1,6 +1,7 @@
 use cosmwasm_std::{QuerierWrapper, StdResult, Uint64};
 
-use crate::query::{BabylonQuery, CurrentEpochResponse};
+use crate::query::{BabylonQuery, BtcTipResponse, CurrentEpochResponse};
+use crate::types::BtcBlockHeaderInfo;
 
 pub struct BabylonQuerier<'a> {
     querier: &'a QuerierWrapper<'a, BabylonQuery>,
@@ -21,5 +22,11 @@ impl<'a> BabylonQuerier<'a> {
         let request = BabylonQuery::LatestFinalizedEpoch {}.into();
         let res: CurrentEpochResponse = self.querier.query(&request)?;
         Ok(Uint64::new(res.epoch))
+    }
+
+    pub fn btc_tip(&self) -> StdResult<BtcBlockHeaderInfo> {
+        let request = BabylonQuery::BtcTip {}.into();
+        let res: BtcTipResponse = self.querier.query(&request)?;
+        Ok(res.header_info)
     }
 }

--- a/packages/bindings/src/query.rs
+++ b/packages/bindings/src/query.rs
@@ -1,3 +1,4 @@
+use crate::types::BtcBlockHeaderInfo;
 use cosmwasm_schema::{cw_serde, QueryResponses};
 use cosmwasm_std::CustomQuery;
 
@@ -9,6 +10,9 @@ pub enum BabylonQuery {
 
     #[returns(LatestFinalizedEpochResponse)]
     LatestFinalizedEpoch {},
+
+    #[returns(BtcTipResponse)]
+    BtcTip {},
 }
 
 #[cw_serde]
@@ -18,6 +22,11 @@ pub struct CurrentEpochResponse {
 #[cw_serde]
 pub struct LatestFinalizedEpochResponse {
     pub epoch: u64,
+}
+
+#[cw_serde]
+pub struct BtcTipResponse {
+    pub header_info: BtcBlockHeaderInfo,
 }
 
 impl CustomQuery for BabylonQuery {}

--- a/packages/bindings/src/types.rs
+++ b/packages/bindings/src/types.rs
@@ -1,0 +1,19 @@
+use cosmwasm_schema::cw_serde;
+
+#[cw_serde]
+pub struct BtcBlockHeader {
+    pub version: i32,
+    // hex encoded hash of previous block
+    pub prev_blockhash: String,
+    // hex encoded merkle root of transactions
+    pub merkle_root: String,
+    pub time: u32,
+    pub bits: u32,
+    pub nonce: u32,
+}
+
+#[cw_serde]
+pub struct BtcBlockHeaderInfo {
+    pub header: BtcBlockHeader,
+    pub height: u64,
+}


### PR DESCRIPTION
Initial pr for returning data from our btc light client module.

There were few possibilities how return type could look like (`BtcBlockHeaderInfo`) :
1. return whole `BTCHeaderInfo` from Babylon - main drawback is that contains header as bytes so it forces caller to use some btc library to deserialize it, also it is a bit internal representation and I think sharing it through ffi is a bit no-go
2. return whole header as hex encoded bytes along with height - again it forces caller to use some btc library to deserialize it
3. return deserialised header along with height - I think drawback here is that for fields `merkle_root` and `prev_blockhash` hex encoding format in a bit ambgious i.e it could be either standard hex encoding or btc hex encoding (reverse byte order). Imo it should be btc hex encoding for compatibility with every every btc infra there is.

Ultimately I have approach 3) as imo it is most easy for the callers, but if some one has other opinions this is pr to discuss it